### PR TITLE
fix: resolve deadlock between project-management and upload during provisioning

### DIFF
--- a/apps/project-management/src/config-project-provisioning.service.ts
+++ b/apps/project-management/src/config-project-provisioning.service.ts
@@ -81,12 +81,17 @@ export class ConfigProjectProvisioningService implements OnModuleInit, OnApplica
 
       // Delegate config content provisioning (revisions, groups, S3 cache) to upload
       await lastValueFrom(
-        this.uploadClient.send(UploadTopics.CONFIG_PROVISION_PROJECT_CONTENT, {
+        this.uploadClient.emit(UploadTopics.CONFIG_PROVISION_PROJECT_CONTENT, {
           projectId: project.id,
           deviceId,
           deviceTypeIds,
         }),
-      );
+      ).catch((err) => {
+        this.logger.warn(
+          `Config content provisioning call failed for device ${deviceId} (project ${project?.id}): ${err?.message ?? err}. ` +
+          `The project entity was created – content will be provisioned on next revision apply.`,
+        );
+      });
     }
 
     return project.id;


### PR DESCRIPTION
## Summary

Fixes a deadlock that occurs when project-management triggers content provisioning in the upload service. The inter-service call used `send` / `@MessagePattern` (request/reply), which blocks project-management until upload completes — but upload calls back to project-management, creating a circular wait. Both sides are updated: project-management now uses `emit` (fire-and-forget) and upload switches to `@EventPattern`. Error handling is added on both sides so a transient failure doesn't break provisioning.

## Repos Involved

| Repo | Branch | Commits ahead |
|------|--------|---------------|
| project-management | fix-deadlock-bug-between-project-and-upload | 1 |
| upload | fix-deadlock-bug-between-project-and-upload | 1 |

## Changes

### project-management

- Changed `uploadClient.send` → `uploadClient.emit` for `CONFIG_PROVISION_PROJECT_CONTENT`, so the call is fire-and-forget and project-management is not blocked.
- Added `.catch()` with a warning log — if the emit fails, the project entity is still created and content will be provisioned on the next revision apply.

### upload

- Changed `CONFIG_PROVISION_PROJECT_CONTENT` handler from `@MessagePattern` to `@EventPattern` in `config.controller.ts` to match the emit-based call.
- Wrapped `assembleAndCacheDeviceConfig` in try/catch — if S3 upload fails during provisioning (e.g., project-management not reachable for a callback), the error is logged as a warning and provisioning continues. Cache is populated on next config apply.

## Integration Notes

project-management emits the `CONFIG_PROVISION_PROJECT_CONTENT` event to upload. Upload handles it asynchronously without replying. Both sides tolerate failure independently: project-management catches emit errors, upload catches S3 upload errors.

## Testing

- Verified that project content provisioning no longer deadlocks when project-management emits the event.
- Confirmed that if either side encounters a transient error, it logs a warning and the flow completes without throwing.
